### PR TITLE
ci: try slopless as a static analysis pass

### DIFF
--- a/.github/workflows/slopless.yml
+++ b/.github/workflows/slopless.yml
@@ -1,0 +1,47 @@
+# Static analysis for AI-slop patterns: https://github.com/fabriziosalmi/slopless
+#
+# Trial run. Findings go to the Security tab and do NOT fail the build, so the
+# rules have to earn their place here before they can block anything.
+name: slopless
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyse:
+    name: AI-slop static analysis
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
+      # Pinned to a commit rather than @v1: a moving tag means trusting the
+      # upstream repository not to change under us.
+      - name: Run slopless
+        continue-on-error: true
+        uses: fabriziosalmi/slopless@a9177f6333d731ec620d786638cf26639708b606 # v1.2.2
+        with:
+          patterns: "src/**/*.ts src/**/*.tsx *.md"
+          format: sarif
+          output: slopless.sarif
+
+      # A fork pull request gets a read-only token whatever `permissions:` says,
+      # so the upload would 403 and fail the job it promises not to fail.
+      - name: Upload findings to code scanning
+        if: >-
+          always()
+          && hashFiles('slopless.sarif') != ''
+          && (github.event_name != 'pull_request'
+              || github.event.pull_request.head.repo.full_name == github.repository)
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@6f5948dfacef28e207b48d0905cf90c03365536d # v3.37.9
+        with:
+          sarif_file: slopless.sarif
+          category: slopless


### PR DESCRIPTION
Part of the slopless rollout across the TypeScript and JavaScript repositories.

## What it does

Runs [slopless](https://github.com/fabriziosalmi/slopless) on push and pull
requests, writes SARIF, uploads it to the Security tab. **It cannot fail the
build**: `continue-on-error` is deliberate for the trial.

## Baseline

**55 findings, zero errors.** The cleanest repository in the rollout so far, and
the only one that would already pass with the trial guard removed.

| Rule | Count |
| --- | --- |
| `VBC-948` em-dash-prose | 15 |
| `VBC-084` long-line-limit | 15 |
| `VBC-057` use-any | 11 |
| `VBC-347` passive-voice | 3 |

`VBC-948` is an opinionated rule about em dashes in prose and is the first thing
to switch off if the style here is deliberate. `VBC-057` is the one worth reading:
eleven `any` annotations is a real signal in a TypeScript project.

Given there are no errors, this is also the natural candidate to make blocking
first, by dropping `continue-on-error` once the warnings are triaged.