### PR TITLE
ci: let slopless fail the build on errors

### DIFF
--- a/.github/workflows/slopless.yml
+++ b/.github/workflows/slopless.yml
@@ -1,7 +1,8 @@
 # Static analysis for AI-slop patterns: https://github.com/fabriziosalmi/slopless
 #
-# Trial run. Findings go to the Security tab and do NOT fail the build, so the
-# rules have to earn their place here before they can block anything.
+# Errors fail the build. Warnings are reported to the Security tab and do not,
+# which is what makes them safe to leave on. Run `slopless --min-severity error`
+# locally to see exactly what would block.
 name: slopless
 
 on:
@@ -25,7 +26,6 @@ jobs:
       # Pinned to a commit rather than @v1: a moving tag means trusting the
       # upstream repository not to change under us.
       - name: Run slopless
-        continue-on-error: true
         uses: fabriziosalmi/slopless@a71e5a179a3ecf40da9d91c361e2abed7c69945a # v1.4.3
         with:
           patterns: "src/**/*.ts src/**/*.tsx *.md"


### PR DESCRIPTION
Closes the trial here. Part of
[slopless#18](https://github.com/fabriziosalmi/slopless/issues/18).

## What changes

`continue-on-error` comes off the analysis step. Errors now fail the build.

**Today that changes nothing:** this repository reports **0 errors and 0
warnings**, the only one in the rollout that reports nothing at all. What this
does is keep it that way, by turning the current state into something CI defends
rather than something nobody notices drifting.

## What still cannot fail

The SARIF upload keeps its own `continue-on-error`. A pull request from a fork
gets a read-only token whatever the `permissions:` block says, so the upload
would 403 through no fault of the code.

## Seeing it before pushing

```bash
npx @fabriziosalmi/slopless --min-severity error "src/**/*.ts" "src/**/*.tsx" "*.md"
```

Same rule set, only the findings that would block.