### PR TITLE
Point slopless at the files this project actually has

### DIFF
--- a/.github/workflows/slopless.yml
+++ b/.github/workflows/slopless.yml
@@ -26,9 +26,9 @@ jobs:
       # Pinned to a commit rather than @v1: a moving tag means trusting the
       # upstream repository not to change under us.
       - name: Run slopless
-        uses: fabriziosalmi/slopless@a71e5a179a3ecf40da9d91c361e2abed7c69945a # v1.4.3
+        uses: fabriziosalmi/slopless@957d17140f190b494e2526550dab5d0d8004431f # v1.9.0
         with:
-          patterns: "src/**/*.ts src/**/*.tsx *.md"
+          patterns: "*.ts *.tsx components/**/*.tsx services/**/*.ts *.md"
           format: sarif
           output: slopless.sarif
 


### PR DESCRIPTION
## The check has been passing on nothing

```yaml
patterns: "src/**/*.ts src/**/*.tsx *.md"
```

There is no `src/` directory. The sources are `App.tsx` at the root, `components/` and `services/`. The check is **blocking** and has been matching zero files, which reports success for the same reason an empty room is quiet.

This is the failure mode slopless spent two releases learning to make visible. Every run now ends with a line saying what it read:

```
Checked 17 files of 140 rules: .tsx 39 rules, .ts 94 rules, .md 16 rules.
```

Before this change that line would have said nothing at all.

## With the patterns corrected

```
Summary: 0 errors, 33 warnings.
```

So the check goes from passing vacuously to passing on 17 real files, and nothing has to be fixed to get there.

## Also here

The pin moves to `v1.9.0`, which adds two rules chosen by measurement: a committed merge conflict marker, and a committed `describe.only` that runs one test and reports green. Across 7,179 files from every instrumented repository the two produce zero findings.