### PR TITLE
Say out loud when findings do not reach the Security tab

### DIFF
--- a/.github/workflows/slopless.yml
+++ b/.github/workflows/slopless.yml
@@ -35,6 +35,7 @@ jobs:
       # A fork pull request gets a read-only token whatever `permissions:` says,
       # so the upload would 403 and fail the job it promises not to fail.
       - name: Upload findings to code scanning
+        id: upload
         if: >-
           always()
           && hashFiles('slopless.sarif') != ''
@@ -45,3 +46,11 @@ jobs:
         with:
           sarif_file: slopless.sarif
           category: slopless
+
+      # A tolerated failure is still a failure, and from the pull request page it
+      # looks like nothing happened. An annotation says so where it is read,
+      # without turning a code-scanning API hiccup into a red build: the findings
+      # are in the log above either way, and an error has already failed the job.
+      - name: Say so if the findings did not reach the Security tab
+        if: always() && steps.upload.outcome == 'failure'
+        run: echo "::warning title=slopless::The analysis ran and the upload to code scanning did not. Findings are in the job log; the Security tab is stale for this commit."


### PR DESCRIPTION
## Why

Copilot made this point on [agssh#58](https://github.com/fabriziosalmi/agssh/pull/58), and it was right about the part I first argued with.

The SARIF upload carries `continue-on-error: true`. That is deliberate — a fork pull request gets a read-only token whatever `permissions:` says, so the upload would 403 and fail a job whose whole promise is that only a slopless error fails it. But a tolerated failure is visible **inside the run and nowhere else**: the check is green, and from this page it looks like nothing happened.

## What changes

```yaml
- name: Say so if the findings did not reach the Security tab
  if: always() && steps.upload.outcome == "failure"
  run: echo "::warning title=slopless::The analysis ran and the upload to code scanning did not..."
```

An annotation appears on the run summary and on the pull request, where it is actually read. The build stays green.

## What does not change

The upload still does not fail the job. This workflow makes one promise — a slopless error fails it — and turning a code-scanning API hiccup into a red build breaks that promise in the other direction. What is lost when an upload fails is the Security tab history for warnings; the findings are in the job log, and if there were errors the job has already failed on them.

Same change across every repository running this workflow, so they keep one shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)