### PR TITLE
Bump slopless to v1.11.0

### DIFF
--- a/.github/workflows/slopless.yml
+++ b/.github/workflows/slopless.yml
@@ -26,7 +26,7 @@ jobs:
       # Pinned to a commit rather than @v1: a moving tag means trusting the
       # upstream repository not to change under us.
       - name: Run slopless
-        uses: fabriziosalmi/slopless@957d17140f190b494e2526550dab5d0d8004431f # v1.9.0
+        uses: fabriziosalmi/slopless@7837fd959b607919593ed7ca6a23d2f8f9d4391f # v1.11.0
         with:
           patterns: "*.ts *.tsx components/**/*.tsx services/**/*.ts *.md"
           format: sarif


### PR DESCRIPTION
Pin only. Two fixes since, both found by pointing slopless at five more repositories.

**Code nobody here wrote is skipped by default.** A Django project reported 2,436 errors, of which 2,419 were `var` inside `vendor/xregexp.js`, `vendor/select2`, `vendor/jquery` and collected `staticfiles` — real matches, in libraries nobody in that repository wrote. `--init` has written those paths into `.sloplessignore` all along; applying them without being asked is the difference between a tool that is right by default and one that is right once you have read the manual. The run reports how many files it set aside.

**A link is broken only when the server says it is not there.** `VBC-401` was non-deterministic: three identical runs over one repository gave 1, 4 and 4 findings, because a slow server, a rate limit and a bot block were all reported as broken. Only 404, 410 and a DNS answer of "no such host" count now. Four identical runs give the same number.

Also carries 1.10.0, where the secret rule learned that an underscore is a word character — `\bsecret\b` never matched `AWS_SECRET_ACCESS_KEY`, the commonest real case — and that a value with a space is not a credential.

This repository was measured with its own patterns before the bump: **unchanged**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)