### PR TITLE
Move the checkout pin off a deprecated Node 20 action

### DIFF
--- a/.github/workflows/slopless.yml
+++ b/.github/workflows/slopless.yml
@@ -21,7 +21,7 @@ jobs:
     name: AI-slop static analysis
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Pinned to a commit rather than @v1: a moving tag means trusting the
       # upstream repository not to change under us.


### PR DESCRIPTION
## Why

The runner already says this, on every run of this workflow:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/checkout@11d5960a`

Being force-migrated onto a runtime the action was not built for is a worse position than choosing the upgrade and watching it. When GitHub finishes retiring Node 20 the warning becomes a failure.

## What changes

One line: the `actions/checkout` pin moves from `v4.4.0` to `v7.0.1`.

`checkout` v7 blocks checking out a fork pull request under `pull_request_target` and `workflow_run`; this workflow uses neither. v6 persists credentials to a separate file, which nothing here depends on. Nothing else about the check moves — same slopless pin, same patterns, same behaviour.

The same upgrade went into slopless itself in [slopless#22](https://github.com/fabriziosalmi/slopless/pull/22), where it was noted that the repositories running the action would need it too. This is that sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)