### PR TITLE
Move the SARIF upload off a deprecated Node 20 action

### DIFF
--- a/.github/workflows/slopless.yml
+++ b/.github/workflows/slopless.yml
@@ -42,7 +42,7 @@ jobs:
           && (github.event_name != 'pull_request'
               || github.event.pull_request.head.repo.full_name == github.repository)
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@6f5948dfacef28e207b48d0905cf90c03365536d # v3.37.9
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: slopless.sarif
           category: slopless


### PR DESCRIPTION
## Why

With `actions/checkout` upgraded, the runner still prints this on every run — now naming the other action:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `github/codeql-action/upload-sarif@6f5948df`

## Why the major bump is safe

The `3.x` and `4.x` lines of `codeql-action` are released together, same day, same number. Rather than take that on trust, here is the entire difference between the two `upload-sarif/action.yml` files:

```diff
44c44
<   using: node20
---
>   using: node24
```

Same inputs, same entry point, same behaviour. The major exists to carry the runtime.

## What changes

One line: the `upload-sarif` pin moves from `v3.37.9` to `v4.37.9`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)