### PR TITLE
build: pin slopless to v1.12.1

### DIFF
--- a/.github/workflows/slopless.yml
+++ b/.github/workflows/slopless.yml
@@ -26,7 +26,7 @@ jobs:
       # Pinned to a commit rather than @v1: a moving tag means trusting the
       # upstream repository not to change under us.
       - name: Run slopless
-        uses: fabriziosalmi/slopless@7837fd959b607919593ed7ca6a23d2f8f9d4391f # v1.11.0
+        uses: fabriziosalmi/slopless@b3a4017bc0e382013da28564dab3b5ee4e23f981 # v1.12.1
         with:
           patterns: "*.ts *.tsx components/**/*.tsx services/**/*.ts *.md"
           format: sarif


### PR DESCRIPTION
Mechanical pin bump, `v1.12.1`.

Between the version pinned here and this one, slopless only **stopped** reporting things:

- **`var(--x)` in an inline `<style>` is CSS** asking for a custom property, not a JavaScript declaration. `VBC-005` was reporting 23 of them in one file.
- **A literal prefix settles the scheme before the value arrives.** ``href={`/blog/${slug}`}`` cannot become `javascript:` whatever `slug` is, so `VBC-944` now fires only when the interpolation is what decides the scheme.
- **Appending a literal clause concatenates no value.** `q += " ORDER BY acquired DESC;"` is not SQL built from input; `VBC-004` now asks that a value actually arrive.

Nine repositories were measured across the change and none moved. Astro also went from 1 rule to 82 in 1.12.0, which does not change what is read here.

The check runs on this PR, so whether the count moved is visible below rather than asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)