### PR TITLE
build: pin slopless to v1.13.0

### DIFF
--- a/.github/workflows/slopless.yml
+++ b/.github/workflows/slopless.yml
@@ -26,7 +26,7 @@ jobs:
       # Pinned to a commit rather than @v1: a moving tag means trusting the
       # upstream repository not to change under us.
       - name: Run slopless
-        uses: fabriziosalmi/slopless@b3a4017bc0e382013da28564dab3b5ee4e23f981 # v1.12.1
+        uses: fabriziosalmi/slopless@982d806db6ac9abb538e1810187987428e9cc1a0 # v1.13.0
         with:
           patterns: "*.ts *.tsx components/**/*.tsx services/**/*.ts *.md"
           format: sarif


### PR DESCRIPTION
Pin bump to `v1.13.0`.

**The rules now read `.tsx`: 39 of 150 becomes 97.** No commit ever decided `.tsx` was out — the rules were written with `ts` in 1.0.0, `astro` was added to many of them in 1.12.0, and `tsx` was never revisited. It was measured across 525 `.tsx` files before being turned on.

`long-line-limit` stays out of `.tsx` on purpose, and the number is the reason: over 525 `.tsx` and 716 `.ts` files from the same repositories, lines past 120 characters run **8.0 per `.tsx` file against 0.7 per `.ts`**. That is JSX — a `className` string and three props on one tag — not a difference in how the code was written.

Everything else in this range only ever removed reports:

- **`VBC-901`** stops reporting the ranges RFC 5737 reserves *for documentation* (`192.0.2.0/24`, `198.51.100.0/24`, `203.0.113.0/24`), and anything starting with `255`, which is reserved space and so a netmask rather than a host.
- **`VBC-001`** gained the test-file exclusion every comparable rule already had, and stopped reading `TOKEN_ADDRESS = '0x…'` as a credential — an address is public by construction.
- **`VBC-080`** stopped reporting `alert(text: string): void {`, which is a method declaration.
- **`VBC-944`** and **`VBC-921`** stopped reporting the fix they ask for: an `href` built from `import.meta.env`, and a copyright range whose end is generated at build time.
- **Framework build caches** inside the source tree — `.vitepress/cache/`, `.astro/`, `.svelte-kit/`, `.nuxt/`, `__pycache__/` and the rest — are no longer read.

The check runs on this PR, so whether the count moved is visible below rather than asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)