### PR TITLE
build: pin slopless to v1.17.0

### DIFF
--- a/.github/workflows/slopless.yml
+++ b/.github/workflows/slopless.yml
@@ -26,7 +26,7 @@ jobs:
       # Pinned to a commit rather than @v1: a moving tag means trusting the
       # upstream repository not to change under us.
       - name: Run slopless
-        uses: fabriziosalmi/slopless@982d806db6ac9abb538e1810187987428e9cc1a0 # v1.13.0
+        uses: fabriziosalmi/slopless@dbee19ee7aeb728821c0886fe02bea67b14eeb25 # v1.17.0
         with:
           patterns: "*.ts *.tsx components/**/*.tsx services/**/*.ts *.md"
           format: sarif


### PR DESCRIPTION
Pin bump to `v1.17.0` — five releases in one step.

## What changes for a build

- **`1.13.1` closed an SSRF in the link checker.** `VBC-401` fetches the URLs written in Markdown, and the workflow triggers on `pull_request`, **forks included** — so the URL was an attacker-supplied string and the CI runner was the thing making the request. A link to `http://169.254.169.254/` was a request the runner made. Private and reserved addresses are refused now, validated on the address the connection *actually uses* rather than one a preliminary lookup returned, and redirects are no longer followed.
- The same release stopped **`--fix` writing a file that no longer parses** — turning both `var a` in a scope into `let a` leaves something `node --check` refuses, and the fixes are now dropped rather than written.
- **`1.14.0` added two rules**, both measured before being written: a **committed private key** (`.pem`/`.key` read for the header, `.p12`/`.pfx` settled by the extension — certificates are public and not reported), and **`window.open` without `noopener`**. An anchor with `target="_blank"` has had implied `noopener` in every browser since 2021; `window.open` never has.
- **`1.15.x`** reads `.gitignore`, and the ignore list is one list rather than two.
- **`1.16.0` stopped four false positives**, measured across 2,892 files: a rule's own test fixtures (they exist *because* they must fire), console output in a file that opens with a shebang (a program's stdout is its interface), a module imported under its own name (`const fs = require('fs')` is not shadowing `fs`), and `VBC-001` reading `.yml` as well as `.yaml`. **138 findings removed, none added.**

Everything except the two new rules only ever **removed** reports.

The check runs on this pull request, so whether the count moved is visible below rather than asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)